### PR TITLE
Fix quotes

### DIFF
--- a/dist/curl-generator.cjs.js
+++ b/dist/curl-generator.cjs.js
@@ -19,20 +19,20 @@ function rawBodyToString(body) {
     return body.content;
 }
 function rawBodyToCommand(body) {
-    return "-d \"" + rawBodyToString(body) + "\"";
+    return "-d '" + rawBodyToString(body) + "'";
 }
 
 function isCurlJsonBody(body) {
     return typeof body === "object" && body !== null && "type" in body && body.type === "json" && "content" in body;
 }
 function jsonContentToString(content) {
-    return JSON.stringify(content).replace(/([\\"])/g, "\\$1");
+    return JSON.stringify(content).replace(/([\\'])/g, "\\$1");
 }
 function jsonBodyToString(body) {
     return jsonContentToString(body.content);
 }
 function jsonBodyToCommand(body) {
-    return "-d \"" + jsonBodyToString(body) + "\"";
+    return "-d '" + jsonBodyToString(body) + "'";
 }
 
 function isCurlFormBody(body) {
@@ -40,7 +40,7 @@ function isCurlFormBody(body) {
 }
 function formBodyToCommand(body) {
     if (body.content instanceof URLSearchParams) {
-        return "-d \"" + body.content.toString() + "\"";
+        return "-d '" + body.content.toString() + "'";
     }
     return Object.entries(body.content)
         .map(function (_a) {
@@ -61,10 +61,10 @@ function formBodyToCommand(body) {
 
 function bodyToCommand(body) {
     if (typeof body === "string") {
-        return "-d \"" + body + "\"";
+        return "-d '" + body + "'";
     }
     else if (body instanceof URLSearchParams) {
-        return "-d \"" + body.toString() + "\"";
+        return "-d '" + body.toString() + "'";
     }
     else if (isCurlFileBody(body)) {
         return fileBodyToCommand(body);
@@ -79,7 +79,7 @@ function bodyToCommand(body) {
         return formBodyToCommand(body);
     }
     else if (typeof body === "object") {
-        return "-d \"" + jsonContentToString(body) + "\"";
+        return "-d '" + jsonContentToString(body) + "'";
     }
     throw new Error("Invalid body type: " + body);
 }
@@ -113,7 +113,7 @@ var getCurlHeaders = function (headers) {
     var result = "";
     if (headers) {
         Object.keys(headers).map(function (val) {
-            result += "" + slash + newLine + " -H \"" + val + ": " + headers[val].replace(/(\\|")/g, "\\$1") + "\"";
+            result += "" + slash + newLine + " -H '" + val + ": " + headers[val].replace(/(\\|')/g, "\\$1") + "'";
         });
     }
     return result;

--- a/dist/curl-generator.esm.js
+++ b/dist/curl-generator.esm.js
@@ -15,20 +15,20 @@ function rawBodyToString(body) {
     return body.content;
 }
 function rawBodyToCommand(body) {
-    return "-d \"" + rawBodyToString(body) + "\"";
+    return "-d '" + rawBodyToString(body) + "'";
 }
 
 function isCurlJsonBody(body) {
     return typeof body === "object" && body !== null && "type" in body && body.type === "json" && "content" in body;
 }
 function jsonContentToString(content) {
-    return JSON.stringify(content).replace(/([\\"])/g, "\\$1");
+    return JSON.stringify(content).replace(/([\\'])/g, "\\$1");
 }
 function jsonBodyToString(body) {
     return jsonContentToString(body.content);
 }
 function jsonBodyToCommand(body) {
-    return "-d \"" + jsonBodyToString(body) + "\"";
+    return "-d '" + jsonBodyToString(body) + "'";
 }
 
 function isCurlFormBody(body) {
@@ -36,7 +36,7 @@ function isCurlFormBody(body) {
 }
 function formBodyToCommand(body) {
     if (body.content instanceof URLSearchParams) {
-        return "-d \"" + body.content.toString() + "\"";
+        return "-d '" + body.content.toString() + "'";
     }
     return Object.entries(body.content)
         .map(function (_a) {
@@ -57,10 +57,10 @@ function formBodyToCommand(body) {
 
 function bodyToCommand(body) {
     if (typeof body === "string") {
-        return "-d \"" + body + "\"";
+        return "-d '" + body + "'";
     }
     else if (body instanceof URLSearchParams) {
-        return "-d \"" + body.toString() + "\"";
+        return "-d '" + body.toString() + "'";
     }
     else if (isCurlFileBody(body)) {
         return fileBodyToCommand(body);
@@ -75,7 +75,7 @@ function bodyToCommand(body) {
         return formBodyToCommand(body);
     }
     else if (typeof body === "object") {
-        return "-d \"" + jsonContentToString(body) + "\"";
+        return "-d '" + jsonContentToString(body) + "'";
     }
     throw new Error("Invalid body type: " + body);
 }
@@ -109,7 +109,7 @@ var getCurlHeaders = function (headers) {
     var result = "";
     if (headers) {
         Object.keys(headers).map(function (val) {
-            result += "" + slash + newLine + " -H \"" + val + ": " + headers[val].replace(/(\\|")/g, "\\$1") + "\"";
+            result += "" + slash + newLine + " -H '" + val + ": " + headers[val].replace(/(\\|')/g, "\\$1") + "'";
         });
     }
     return result;

--- a/dist/curl-generator.umd.js
+++ b/dist/curl-generator.umd.js
@@ -21,20 +21,20 @@
       return body.content;
   }
   function rawBodyToCommand(body) {
-      return "-d \"" + rawBodyToString(body) + "\"";
+      return "-d '" + rawBodyToString(body) + "'";
   }
 
   function isCurlJsonBody(body) {
       return typeof body === "object" && body !== null && "type" in body && body.type === "json" && "content" in body;
   }
   function jsonContentToString(content) {
-      return JSON.stringify(content).replace(/([\\"])/g, "\\$1");
+      return JSON.stringify(content).replace(/([\\'])/g, "\\$1");
   }
   function jsonBodyToString(body) {
       return jsonContentToString(body.content);
   }
   function jsonBodyToCommand(body) {
-      return "-d \"" + jsonBodyToString(body) + "\"";
+      return "-d '" + jsonBodyToString(body) + "'";
   }
 
   function isCurlFormBody(body) {
@@ -42,7 +42,7 @@
   }
   function formBodyToCommand(body) {
       if (body.content instanceof URLSearchParams) {
-          return "-d \"" + body.content.toString() + "\"";
+          return "-d '" + body.content.toString() + "'";
       }
       return Object.entries(body.content)
           .map(function (_a) {
@@ -63,10 +63,10 @@
 
   function bodyToCommand(body) {
       if (typeof body === "string") {
-          return "-d \"" + body + "\"";
+          return "-d '" + body + "'";
       }
       else if (body instanceof URLSearchParams) {
-          return "-d \"" + body.toString() + "\"";
+          return "-d '" + body.toString() + "'";
       }
       else if (isCurlFileBody(body)) {
           return fileBodyToCommand(body);
@@ -81,7 +81,7 @@
           return formBodyToCommand(body);
       }
       else if (typeof body === "object") {
-          return "-d \"" + jsonContentToString(body) + "\"";
+          return "-d '" + jsonContentToString(body) + "'";
       }
       throw new Error("Invalid body type: " + body);
   }
@@ -115,7 +115,7 @@
       var result = "";
       if (headers) {
           Object.keys(headers).map(function (val) {
-              result += "" + slash + newLine + " -H \"" + val + ": " + headers[val].replace(/(\\|")/g, "\\$1") + "\"";
+              result += "" + slash + newLine + " -H '" + val + ": " + headers[val].replace(/(\\|')/g, "\\$1") + "'";
           });
       }
       return result;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "curl-generator",
     "author": "albertodeagostini.dev@gmail.com",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "main": "dist/curl-generator.cjs.js",
     "module": "dist/curl-generator.esm.js",
     "browser": "dist/curl-generator.umd.js",

--- a/src/bodies/body.ts
+++ b/src/bodies/body.ts
@@ -36,9 +36,9 @@ export function bodyToString(body: CurlBody): string {
 
 export function bodyToCommand(body: CurlBody): string {
   if (typeof body === "string") {
-    return `-d "${body}"`;
+    return `-d '${body}'`;
   } else if (body instanceof URLSearchParams) {
-    return `-d "${body.toString()}"`;
+    return `-d '${body.toString()}'`;
   } else if (isCurlFileBody(body)) {
     return fileBodyToCommand(body);
   } else if (isCurlRawBody(body)) {
@@ -48,7 +48,7 @@ export function bodyToCommand(body: CurlBody): string {
   } else if (isCurlFormBody(body)) {
     return formBodyToCommand(body);
   } else if (typeof body === "object") {
-    return `-d "${jsonContentToString(body)}"`;
+    return `-d '${jsonContentToString(body)}'`;
   }
 
   throw new Error(`Invalid body type: ${body}`);

--- a/src/bodies/form-body.ts
+++ b/src/bodies/form-body.ts
@@ -44,7 +44,7 @@ export function isCurlFormBody(body: unknown): body is CurlFormBody {
 
 export function formBodyToCommand(body: CurlFormBody): string {
   if (body.content instanceof URLSearchParams) {
-    return `-d "${body.content.toString()}"`;
+    return `-d '${body.content.toString()}'`;
   }
 
   return Object.entries(body.content)

--- a/src/bodies/json-body.ts
+++ b/src/bodies/json-body.ts
@@ -17,7 +17,7 @@ export function isCurlJsonBody(body: unknown): body is CurlJsonBody {
 
 export function jsonContentToString(content: Record<string | number | symbol, unknown>): string {
   return JSON.stringify(content).replace(
-    /([\\"])/g,
+    /([\\'])/g,
     "\\$1"
   );
 }
@@ -27,5 +27,5 @@ export function jsonBodyToString(body: CurlJsonBody): string {
 }
 
 export function jsonBodyToCommand(body: CurlJsonBody): string {
-  return `-d "${jsonBodyToString(body)}"`;
+  return `-d '${jsonBodyToString(body)}'`;
 }

--- a/src/bodies/raw-body.ts
+++ b/src/bodies/raw-body.ts
@@ -20,5 +20,5 @@ export function rawBodyToString(body: CurlRawBody): string {
 }
 
 export function rawBodyToCommand(body: CurlRawBody): string {
-  return `-d "${rawBodyToString(body)}"`;
+  return `-d '${rawBodyToString(body)}'`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,10 +86,10 @@ const getCurlHeaders = function (headers?: StringMap): string {
   let result = "";
   if (headers) {
     Object.keys(headers).map((val) => {
-      result += `${slash}${newLine} -H "${val}: ${headers[val].replace(
-        /(\\|")/g,
+      result += `${slash}${newLine} -H '${val}: ${headers[val].replace(
+        /(\\|')/g,
         "\\$1"
-      )}"`;
+      )}'`;
     });
   }
   return result;

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -8,36 +8,36 @@ exports[`del1 1`] = `
 exports[`fileBody 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: application/json" \\
+ -H 'Content-Type: application/json' \\
  --data-binary @data.json"
 `;
 
 exports[`formBody1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: application/x-www-form-urlencoded" \\
+ -H 'Content-Type: application/x-www-form-urlencoded' \\
  -F name=foo"
 `;
 
 exports[`formBody2 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: multipart/form-data" \\
+ -H 'Content-Type: multipart/form-data' \\
  -F file1=@data.json"
 `;
 
 exports[`formBody3 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: application/x-www-form-urlencoded" \\
+ -H 'Content-Type: application/x-www-form-urlencoded' \\
  -F file1=string data"
 `;
 
 exports[`formBody4 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: application/x-www-form-urlencoded" \\
- -d "key1=value+1""
+ -H 'Content-Type: application/x-www-form-urlencoded' \\
+ -d 'key1=value+1'"
 `;
 
 exports[`get1 1`] = `"curl https://jsonplaceholder.typicode.com/posts/101 \\"`;
@@ -50,20 +50,20 @@ exports[`get2 1`] = `
 exports[`getEscapeHeaders 1`] = `
 "curl https://jsonplaceholder.typicode.com/todos/1 \\
  -X GET \\
- -H "key: a \\"strange\\" value""
+ -H 'key: a "strange" value'"
 `;
 
 exports[`getWithHeaders 1`] = `
 "curl https://jsonplaceholder.typicode.com/todos/1 \\
  -X GET \\
- -H "Content-Type: application/json""
+ -H 'Content-Type: application/json'"
 `;
 
 exports[`jsonBody 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: application/json" \\
- -d "{\\"name\\":\\"foo\\"}""
+ -H 'Content-Type: application/json' \\
+ -d '{"name":"foo"}'"
 `;
 
 exports[`opt1 1`] = `
@@ -81,41 +81,41 @@ exports[`opt2 1`] = `
 exports[`patch1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts/1 \\
  -X PATCH \\
- -H "Content-type: application/json; charset=UTF-8" \\
- -d "{\\"title\\":\\"foo patched\\"}""
+ -H 'Content-type: application/json; charset=UTF-8' \\
+ -d '{"title":"foo patched"}'"
 `;
 
 exports[`post1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-type: application/json; charset=UTF-8" \\
- -d "{\\"id\\":\\"123-456-789\\",\\"key1\\":\\"value 1\\",\\"key2\\":\\"a \\\\\\"complex\\\\\\" value\\"}""
+ -H 'Content-type: application/json; charset=UTF-8' \\
+ -d '{"id":"123-456-789","key1":"value 1","key2":"a \\\\"complex\\\\" value"}'"
 `;
 
 exports[`put1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts/1 \\
  -X PUT \\
- -H "Content-type: application/json; charset=UTF-8" \\
- -d "{\\"id\\":1,\\"title\\":\\"foo\\",\\"body\\":\\"barzzz\\",\\"userId\\":1}""
+ -H 'Content-type: application/json; charset=UTF-8' \\
+ -d '{"id":1,"title":"foo","body":"barzzz","userId":1}'"
 `;
 
 exports[`rawBody1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: text/plain" \\
- -d "string data""
+ -H 'Content-Type: text/plain' \\
+ -d 'string data'"
 `;
 
 exports[`rawBody2 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: text/plain" \\
- -d "string data""
+ -H 'Content-Type: text/plain' \\
+ -d 'string data'"
 `;
 
 exports[`searchParamsBody 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\
- -H "Content-Type: text/plain" \\
- -d "key1=value+1""
+ -H 'Content-Type: text/plain' \\
+ -d 'key1=value+1'"
 `;


### PR DESCRIPTION
# Switch from double quotes to single quotes in curl commands

## Summary
This PR changes the quoting style in generated curl commands from double quotes to single quotes. This makes the generated commands more compatible with various shell environments and avoids common escaping issues when working with JSON payloads.

## Changes
- Changed all `-d "..."` parameters to use single quotes: `-d '...'`
- Changed all `-H "..."` header parameters to use single quotes: `-H '...'`
- Updated the escaping pattern in `jsonContentToString()` to handle single quotes instead of double quotes
- Updated all test snapshots to reflect the new quoting style

## Benefits
- Improved compatibility with different shell environments
- Easier to copy-paste commands that contain JSON with double quotes
- More consistent with common curl usage patterns in documentation and examples

## Testing
All existing tests pass with the updated snapshots.
